### PR TITLE
Update role to work with drbd9 (and more)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,18 @@ drbd_interface: enp0s8
 drbd_network_shared_secret: wXE8MqVa
 
 drbd_vip: 192.168.250.100
+```
 
+For each node
+
+```yaml
+---
+drbd_node_id: 0
 ```
 
 Additional variables include
 
-```
+```yaml
 drbd_use_heartbeat: true
 drbd_use_parted: true
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,8 @@ drbd_network_shared_secret: wXE8MqVa
 
 drbd_vip: 192.168.250.100
 
+drbd_connection_mesh: false
+
 # Debian9/Ubuntu have included drbd support.
 drbd_deb_packages: ['drbd8-utils']
 # Additional yum repo required. See ELREPO for prebuilt RHEL RPMS, or your local site administrator.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,8 @@ drbd_vip: 192.168.250.100
 
 drbd_connection_mesh: false
 
+drbd_quorum: false
+
 # Debian9/Ubuntu have included drbd support.
 drbd_deb_packages: ['drbd8-utils']
 # Additional yum repo required. See ELREPO for prebuilt RHEL RPMS, or your local site administrator.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,7 +26,8 @@ drbd_interface: enp0s8
 
 drbd_network_shared_secret: wXE8MqVa
 
-drbd_vip: 192.168.250.100
+drbd_vip:
+  - 192.168.250.100
 
 drbd_connection_mesh: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,8 +37,15 @@ drbd_deb_packages: ['drbd8-utils']
 # Additional yum repo required. See ELREPO for prebuilt RHEL RPMS, or your local site administrator.
 drbd_rpm_packages: ['drbd84-utils', 'kmod-drbd84']
 
-# Toggle
-drbd_use_heartbeat: true
 drbd_use_parted: true
+
+# Heartbeat variables
+drbd_use_heartbeat: true
 drbd_unicast_mode: false
 drbd_unicast_port: 694
+
+drbd_ha_keepalive: 1
+drbd_ha_deadtime: 10
+drbd_ha_initdead: 60
+drbd_ha_auto_failback: "off"
+drbd_ha_resources: []

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -67,9 +67,10 @@
         inventory_hostname == groups[drbd_group][0]
 
 - name: config | Waiting For DRBD Sync To Complete
-  command: drbd-overview
+  command: drbdadm status {{ item['resource'] }}
   become: true
   register: _drbd_sync
+  with_items: "{{ drbd_disks }}"
   until: ('Inconsistent' not in _drbd_sync['stdout'])
   retries: 100
   delay: 30

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -46,7 +46,7 @@
   changed_when: _drbd_mirror_device_up.stderr.find("volume exists already") == -1
 
 - name: config | Defining DRBD Primary
-  command: drbdadm -- --overwrite-data-of-peer primary {{ item['resource'] }}/0
+  command: drbdadm primary --force {{ item['resource'] }}
   become: true
   register: _drbd_primary
   with_items: "{{ drbd_disks }}"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -25,7 +25,7 @@
   become: true
   register: _drbd_mirror_device_created
   with_items: "{{ _drbd_mirror_device_creation_status['results'] }}"
-  when: not item['stat']['exists']
+  when: not item['stat']['exists'] and drbd_quorum is sameas false
 
 - name: config | Marking DRDB Mirror Devices Created
   file:
@@ -40,8 +40,10 @@
   become: true
   register: _drbd_mirror_device_up
   with_items: "{{ drbd_disks}}"
-  when: >
-        _drbd_mirror_device_created['changed']
+  failed_when: >
+    _drbd_mirror_device_up.rc != 0 and
+    _drbd_mirror_device_up.stderr.find("volume exists already") == -1
+  changed_when: _drbd_mirror_device_up.stderr.find("volume exists already") == -1
 
 - name: config | Defining DRBD Primary
   command: drbdadm -- --overwrite-data-of-peer primary {{ item['resource'] }}/0
@@ -79,6 +81,7 @@
     state: directory
   become: true
   with_items: "{{ drbd_disks }}"
+  when: drbd_quorum is sameas false
 
 - name: config | Updating /etc/fstab Mounts
   mount:
@@ -89,3 +92,4 @@
     state: present
   become: true
   with_items: "{{ drbd_disks }}"
+  when: drbd_quorum is sameas false

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -45,6 +45,18 @@
     _drbd_mirror_device_up.stderr.find("volume exists already") == -1
   changed_when: _drbd_mirror_device_up.stderr.find("volume exists already") == -1
 
+- name: config | Waiting For DRBD Node To Be Ready
+  command: drbdadm status {{ item['resource'] }}
+  become: true
+  register: _drbd_ready
+  with_items: "{{ drbd_disks }}"
+  until: ('Connecting' not in _drbd_ready['stdout'])
+  retries: 100
+  delay: 5
+  when: >
+    _drbd_mirror_device_up['changed'] and
+    inventory_hostname == groups[drbd_group][0]
+
 - name: config | Defining DRBD Primary
   command: drbdadm primary --force {{ item['resource'] }}
   become: true

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -72,7 +72,7 @@
   register: _drbd_sync
   with_items: "{{ drbd_disks }}"
   until: ('Inconsistent' not in _drbd_sync['stdout'])
-  retries: 100
+  retries: 300
   delay: 30
   when: >
         _drbd_primary['changed'] and

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -105,4 +105,6 @@
     state: present
   become: true
   with_items: "{{ drbd_disks }}"
-  when: drbd_quorum is sameas false
+  when: >
+    drbd_quorum is sameas false and
+    drbd_use_heartbeat is sameas false

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -21,7 +21,7 @@
   with_items: "{{ drbd_disks }}"
 
 - name: config | Creating DRBD Mirror Devices
-  command: drbdadm create-md {{ item['item']['resource'] }}
+  command: drbdadm create-md {{ item['item']['resource'] }} --force
   become: true
   register: _drbd_mirror_device_created
   with_items: "{{ _drbd_mirror_device_creation_status['results'] }}"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -88,7 +88,7 @@
     path: "{{ item['mountpoint'] }}"
     src: "{{ item['device'] }}"
     fstype: "{{ item['filesystem'] }}"
-    opts: "{{ item['mountopts'] }}"
+    opts: "{{ item['mountopts'] | default('defaults,_netdev,noatime') }}"
     state: present
   become: true
   with_items: "{{ drbd_disks }}"

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,10 +1,9 @@
 ---
 - name: debian | Installing DRBD packages
   apt:
-    name: "{{ item }}"
+    name: "{{ drbd_deb_packages }}"
     state: present
   become: true
-  with_items: "{{ drbd_deb_packages }}"
 
 - name: debian | Installing Heartbeat Package
   apt:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 # tasks file for ansible-drbd
 
+- name: Set quorum fact
+  set_fact:
+    drbd_quorum: "{{ drbd_quorum }}"
+
 - include_tasks: debian.yml
   tags:
     - drbd
@@ -21,7 +25,7 @@
   tags:
     - drbd
     - drbd-heartbeat
-  when: drbd_use_heartbeat
+  when: drbd_use_heartbeat and drbd_quorum is sameas false
 
 - include_tasks: config.yml
   tags:

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -10,4 +10,4 @@
     name: heartbeat
     enabled: true
   become: true
-  when: drbd_use_heartbeat
+  when: drbd_use_heartbeat and drbd_quorum is sameas false

--- a/templates/etc/drbd.d/global_common.conf.j2
+++ b/templates/etc/drbd.d/global_common.conf.j2
@@ -17,6 +17,8 @@ common {
 resource {{ disk['resource'] }} {
 {%   for host in groups[drbd_group] %}
   on {{ hostvars[host]['inventory_hostname_short'] }} {
+    {% if drbd_node_id is defined %}node-id {{ hostvars[host]['drbd_node_id'] }};
+    {% endif %}
     device {{ disk['device'] }};
     disk {{ disk['use_partition'] }};
     address {{ hostvars[host]['ansible_' + drbd_interface]['ipv4']['address'] }}:7788;

--- a/templates/etc/drbd.d/global_common.conf.j2
+++ b/templates/etc/drbd.d/global_common.conf.j2
@@ -19,9 +19,10 @@ resource {{ disk['resource'] }} {
   on {{ hostvars[host]['inventory_hostname_short'] }} {
     {% if drbd_node_id is defined %}node-id {{ hostvars[host]['drbd_node_id'] }};
 {% endif %}    device {{ disk['device'] }};
-    disk {{ disk['use_partition'] }};
+    disk {% if hostvars[host]['drbd_quorum'] is sameas false %}{{ disk['use_partition'] }}{% else %}none{% endif %};
     address {{ hostvars[host]['ansible_' + drbd_interface]['ipv4']['address'] }}:7788;
-    meta-disk internal;
+{% if hostvars[host]['drbd_quorum'] is sameas false %}    meta-disk internal;
+{% endif %}
   }
 
 {% endfor %}

--- a/templates/etc/drbd.d/global_common.conf.j2
+++ b/templates/etc/drbd.d/global_common.conf.j2
@@ -15,15 +15,19 @@ common {
 
 {% for disk in drbd_disks %}
 resource {{ disk['resource'] }} {
-{%   for host in groups[drbd_group] %}
+{% for host in groups[drbd_group] %}
   on {{ hostvars[host]['inventory_hostname_short'] }} {
     {% if drbd_node_id is defined %}node-id {{ hostvars[host]['drbd_node_id'] }};
-    {% endif %}
-    device {{ disk['device'] }};
+{% endif %}    device {{ disk['device'] }};
     disk {{ disk['use_partition'] }};
     address {{ hostvars[host]['ansible_' + drbd_interface]['ipv4']['address'] }}:7788;
     meta-disk internal;
   }
-{%   endfor %}
+
+{% endfor %}
+{% if drbd_connection_mesh is sameas true %}  connection-mesh {
+    hosts{% for host2 in groups[drbd_group] %} {{ hostvars[host2]['inventory_hostname_short'] }}{% endfor %};
+  }
+{% endif %}
 }
 {% endfor %}

--- a/templates/etc/ha.d/ha.cf.j2
+++ b/templates/etc/ha.d/ha.cf.j2
@@ -12,7 +12,8 @@ auto_failback off
 
 udpport {{ drbd_unicast_port }}
 {% for host in groups[drbd_group] %}
-ucast {{ drbd_interface }} {{ hostvars[host]['ansible_' + drbd_interface]['ipv4']['address'] }}
+{% if hostvars[host]['drbd_quorum'] is sameas false %}ucast {{ drbd_interface }} {{ hostvars[host]['ansible_' + drbd_interface]['ipv4']['address'] }}
+{% endif %}
 {% endfor %}
 
 {% else %}
@@ -20,5 +21,6 @@ bcast {{ drbd_interface }}
 {% endif %}
 
 {% for host in groups[drbd_group] %}
-node {{ hostvars[host]['inventory_hostname_short'] }}
+{% if hostvars[host]['drbd_quorum'] is sameas false %}node {{ hostvars[host]['inventory_hostname_short'] }}
+{% endif %}
 {% endfor %}

--- a/templates/etc/ha.d/ha.cf.j2
+++ b/templates/etc/ha.d/ha.cf.j2
@@ -1,21 +1,17 @@
 # {{ ansible_managed }}
 
 keepalive 1
-
 deadtime 10
-
 initdead 60
 
 auto_failback off
 
 {% if drbd_unicast_mode %}
-
 udpport {{ drbd_unicast_port }}
 {% for host in groups[drbd_group] %}
 {% if hostvars[host]['drbd_quorum'] is sameas false %}ucast {{ drbd_interface }} {{ hostvars[host]['ansible_' + drbd_interface]['ipv4']['address'] }}
 {% endif %}
 {% endfor %}
-
 {% else %}
 bcast {{ drbd_interface }}
 {% endif %}

--- a/templates/etc/ha.d/ha.cf.j2
+++ b/templates/etc/ha.d/ha.cf.j2
@@ -1,12 +1,25 @@
 # {{ ansible_managed }}
 
-keepalive 1
-deadtime 10
-initdead 60
+keepalive {{ drbd_ha_keepalive }}
+deadtime {{ drbd_ha_deadtime }}
+initdead {{ drbd_ha_initdead }}
+{% if drbd_ha_warntime is defined %}warntime {{ drbd_ha_warntime }}
+{% endif %}
+{% if drbd_ha_logfile is defined %}
 
-auto_failback off
+logfile {{ drbd_ha_logfile }}
+{% endif %}
+{% if drbd_ha_debugfile is defined %}
+debugfile {{ drbd_ha_debugfile }}
+{% endif %}
 
+auto_failback {{ drbd_ha_auto_failback }}
+{% if drbd_ha_ping is defined %}
+
+ping {{ drbd_ha_ping }}
+{% endif %}
 {% if drbd_unicast_mode %}
+
 udpport {{ drbd_unicast_port }}
 {% for host in groups[drbd_group] %}
 {% if hostvars[host]['drbd_quorum'] is sameas false %}ucast {{ drbd_interface }} {{ hostvars[host]['ansible_' + drbd_interface]['ipv4']['address'] }}

--- a/templates/etc/ha.d/haresources.j2
+++ b/templates/etc/ha.d/haresources.j2
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
 
 {% for item in drbd_disks %}
-{{ hostvars[groups[drbd_group][0]]['inventory_hostname_short'] }} {{ drbd_vip }} drbddisk::{{ item['resource'] }} Filesystem::{{ item['device'] }}::{{ item['mountpoint'] }}::{{ item['filesystem'] }}::noatime
+{{ hostvars[groups[drbd_group][0]]['inventory_hostname_short'] }} {{ drbd_vip }} drbddisk::{{ item['resource'] }} Filesystem::{{ item['device'] }}::{{ item['mountpoint'] }}::{{ item['filesystem'] }}::noatime {% for res in drbd_ha_resources %}{{ res }}{% endfor %}
 {% endfor %}

--- a/templates/etc/ha.d/haresources.j2
+++ b/templates/etc/ha.d/haresources.j2
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
 
 {% for item in drbd_disks %}
-{{ hostvars[groups[drbd_group][0]]['inventory_hostname_short'] }} {{ drbd_vip }} drbddisk::{{ item['resource'] }} Filesystem::{{ item['device'] }}::{{ item['mountpoint'] }}::{{ item['filesystem'] }}::noatime {% for res in drbd_ha_resources %}{{ res }}{% endfor %}
+{{ hostvars[groups[drbd_group][0]]['inventory_hostname_short'] }} {% for ip in drbd_vip %}IPaddr2::{{ ip }} {% endfor %}drbddisk::{{ item['resource'] }} Filesystem::{{ item['device'] }}::{{ item['mountpoint'] }}::{{ item['filesystem'] }}::noatime {% for res in drbd_ha_resources %}{{ res }}{% endfor %}
 {% endfor %}


### PR DESCRIPTION
Hello,

Tell me if this PR should be split to be accepted.

Below are the changes:
* Capability to have several VIP
  * Previously only one IP could be used in heartbeat configuration
* Add some parameters for heartbeat
  * Improve the options related to heartbeat
* Don't change fstab with heartbeat
  * If using heartbeat the mount is done by heartbeat and not by the system
* Format heartbeat template
* Update sync waiting command
* Add a task to wait before each node is ready
* Use force to define primary node
* Add default value for option mountopts
* Use force to avoid question Do you want to proceed
* Be able to use quorum diskless (drbd9)
* Add the capability to set DRBD connection-mesh (drbd9)
* Remove warning messages with last version of ansible
* Add the capability to set DRBD node-id (drbd9)